### PR TITLE
added prop to control autofocus [delivers #137567159]

### DIFF
--- a/lib/combobox.js
+++ b/lib/combobox.js
@@ -39,8 +39,10 @@ module.exports = React.createClass({
      * Shown when the combobox is empty.
     */
     placeholder: React.PropTypes.string,
-    inputKeydownMap: React.PropTypes.object
+    inputKeydownMap: React.PropTypes.object,
     /*Customization: allows parent to pass in which keys trigger which handlers*/
+    autoFocus: React.PropTypes.bool
+    /*Customization: allows for parent to pass in value to determine if input should autofocus*/
   },
 
   getDefaultProps: function() {
@@ -402,6 +404,7 @@ module.exports = React.createClass({
       input({
         ref: 'input',
         autoComplete: 'off',
+        autoFocus: this.props.autoFocus,
         spellCheck: 'false',
         'aria-label': ariaLabel,
         'aria-expanded': this.state.isOpen+'',

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,7 @@ var li = React.DOM.li;
 
 module.exports = React.createClass({
   propTypes: {
+    autoFocus: React.PropTypes.bool,
     inputKeydownMap: React.PropTypes.object,
     isLoading: React.PropTypes.bool,
     loadingComponent: React.PropTypes.any,
@@ -75,6 +76,7 @@ module.exports = React.createClass({
       tokens,
       li({className: 'inline-flex', ref: 'combo-li'},
         Combobox({
+          autoFocus: this.props.autoFocus,
           id: this.props.id,
           ariaLabel: this.props['combobox-aria-label'],
           ariaDisabled: isDisabled,


### PR DESCRIPTION
@garronmichael @michaelgraham I had to update this library again to allow for us to autofocus on the field when the onboarding slide comes up.  I think this will greatly help with people completing this slide and hopefully completely onboarding.  As soon as this is approved you can merge and do an npm deployment as this new prop is optional so it won't break anything on the decoraid side if it gets released.  Thanks!!